### PR TITLE
Prevent PHP Warning:  openssl_decrypt(): IV passed is only x bytes lo…

### DIFF
--- a/acf-encrypt-field-option.php
+++ b/acf-encrypt-field-option.php
@@ -123,12 +123,13 @@ class acf_encrypt_field_option
             0, 
             $iv
         );
-        return base64_encode($iv.$enc_str);
+        return base64_encode( $iv ) .":". base64_encode($enc_str );
     } 
 
     private function decrypt($enc_str)
     {
-        $str    = base64_decode($enc_str);
+        $fullstr = explode( ":", $enc_str );
+        $str    = base64_decode( $fullstr[0] ) . base64_decode($fullstr[1]); // reassembles $str as it was in original code
         $iv_len = openssl_cipher_iv_length($this->cipher);
         $iv     = substr($str, 0, $iv_len);
         $value  = substr($str, $iv_len);


### PR DESCRIPTION
…ng, cipher expects an IV of precisely 16 bytes, padding with \0

It is suspected that the since the openssl_random_pseudo_bytes(16) function returns raw binary data, it is introducing inconsistencies in the resultant string.

These changes base64 encode the iv and string separately, then reassemble them with a separator that allows for more predictable use of the iv during the decrypt function